### PR TITLE
Plug-65 Feat: 사용자 및 블로그 수정 정보 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-config' # 추후 추가
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -38,6 +39,10 @@ dependencies {
 
 	// Aws S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// open feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/justdo/plug/blog/BlogApplication.java
+++ b/src/main/java/com/justdo/plug/blog/BlogApplication.java
@@ -2,10 +2,12 @@ package com.justdo.plug.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class BlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/justdo/plug/blog/domain/blog/Blog.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/Blog.java
@@ -22,7 +22,8 @@ public class Blog extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
+    @Builder.Default
+    private String title = "블로그 제목을 입력해주세요.";
 
     private String profile;
 

--- a/src/main/java/com/justdo/plug/blog/domain/blog/Blog.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/Blog.java
@@ -25,6 +25,8 @@ public class Blog extends BaseTimeEntity {
     @Builder.Default
     private String title = "블로그 제목을 입력해주세요.";
 
+    private String description;
+
     private String profile;
 
     private String background;

--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -1,9 +1,13 @@
 package com.justdo.plug.blog.domain.blog.controller;
 
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;
 import com.justdo.plug.blog.domain.blog.service.BlogCommandService;
+import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
 import com.justdo.plug.blog.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -16,10 +20,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class BlogController {
 
     private final BlogCommandService blogCommandService;
+    private final BlogQueryService blogQueryService;
 
     @PostMapping("/images")
-    public ApiResponse<ImageResult> uploadBackground(
+    public ApiResponse<ImageResult> uploadImage(
         @RequestPart(name = "imageUrl") MultipartFile multipartFile) {
         return ApiResponse.onSuccess(blogCommandService.imageUpload(multipartFile));
+    }
+
+    @GetMapping("/{blogId}")
+    public ApiResponse<MyBlogResult> myBlog(@PathVariable(name = "blogId") Long blogId) {
+        return ApiResponse.onSuccess(blogQueryService.getBlogInfo(blogId));
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -4,8 +4,7 @@ import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
 import com.justdo.plug.blog.domain.blog.service.BlogCommandService;
 import com.justdo.plug.blog.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,9 +17,9 @@ public class BlogController {
 
     private final BlogCommandService blogCommandService;
 
-    @PatchMapping("/{blogId}/background")
-    public ApiResponse<ImageResult> uploadBackground(@PathVariable Long blogId,
+    @PostMapping("/images")
+    public ApiResponse<ImageResult> uploadBackground(
         @RequestPart(name = "imageUrl") MultipartFile multipartFile) {
-        return ApiResponse.onSuccess(blogCommandService.editBackground(blogId, multipartFile));
+        return ApiResponse.onSuccess(blogCommandService.imageUpload(multipartFile));
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -1,6 +1,7 @@
 package com.justdo.plug.blog.domain.blog.dto;
 
 import com.justdo.plug.blog.domain.blog.Blog;
+import com.justdo.plug.blog.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,18 +15,15 @@ public class BlogResponse {
     @Getter
     public static class MyBlogResult {
 
-        private MemberInfo memberInfo;
+        private Member memberInfo;
         private BlogInfo blogInfo;
     }
 
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
-    public static class MemberInfo {
-
-        private String nickname;
-        private String profile;
+    public static MyBlogResult toMyBlogResult(Member memberInfo, BlogInfo blogInfo) {
+        return MyBlogResult.builder()
+            .memberInfo(memberInfo)
+            .blogInfo(blogInfo)
+            .build();
     }
 
     @Builder

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -1,17 +1,61 @@
 package com.justdo.plug.blog.domain.blog.dto;
 
+import com.justdo.plug.blog.domain.blog.Blog;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class BlogResponse {
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MyBlogResult {
+
+        private MemberInfo memberInfo;
+        private BlogInfo blogInfo;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberInfo {
+
+        private String nickname;
+        private String profile;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogInfo {
+
+        private String title;
+        private String description;
+        private String profile;
+        private String background;
+    }
+
+    public static BlogInfo toBlogInfo(Blog blog) {
+
+        return BlogInfo.builder()
+            .title(blog.getTitle())
+            .description(blog.getDescription())
+            .profile(blog.getProfile())
+            .background(blog.getBackground())
+            .build();
+    }
 
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class ImageResult {
 
-        String imageUrl;
+        private String imageUrl;
     }
 
     public static ImageResult toImageResult(String imageUrl) {

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogCommandService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogCommandService.java
@@ -1,11 +1,8 @@
 package com.justdo.plug.blog.domain.blog.service;
 
-import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
 import com.justdo.plug.blog.domain.blog.repository.BlogRepository;
-import com.justdo.plug.blog.global.exception.ApiException;
-import com.justdo.plug.blog.global.response.code.status.ErrorStatus;
 import com.justdo.plug.blog.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,16 +19,9 @@ public class BlogCommandService {
 
 
     // 블로그 배경사진 수정
-    public ImageResult editBackground(Long blogId, MultipartFile multipartFile) {
-
-        // Blog 조회
-        Blog blog = blogRepository.findById(blogId).orElseThrow(
-            () -> new ApiException(ErrorStatus._BLOG_NOT_FOUND)
-        );
+    public ImageResult imageUpload(MultipartFile multipartFile) {
 
         String imageUrl = s3Service.uploadFile(multipartFile);
-        blog.editBackgroud(imageUrl);
-
         return BlogResponse.toImageResult(imageUrl);
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -1,0 +1,38 @@
+package com.justdo.plug.blog.domain.blog.service;
+
+import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfo;
+import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;
+import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toBlogInfo;
+import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toMyBlogResult;
+
+import com.justdo.plug.blog.domain.blog.Blog;
+import com.justdo.plug.blog.domain.blog.repository.BlogRepository;
+import com.justdo.plug.blog.domain.member.Member;
+import com.justdo.plug.blog.domain.member.MemberClient;
+import com.justdo.plug.blog.global.exception.ApiException;
+import com.justdo.plug.blog.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlogQueryService {
+
+    private final BlogRepository blogRepository;
+    private final MemberClient memberClient;
+
+    public MyBlogResult getBlogInfo(Long blogId) {
+
+        // 나의 블로그 정보 조회
+        Blog blog = blogRepository.findById(blogId)
+            .orElseThrow(() -> new ApiException(ErrorStatus._BLOG_NOT_FOUND));
+        BlogInfo blogInfo = toBlogInfo(blog);
+
+        // 나의 개인 정보 조회
+        Member memberInfo = memberClient.findMember();
+
+        return toMyBlogResult(memberInfo, blogInfo);
+    }
+}

--- a/src/main/java/com/justdo/plug/blog/domain/member/Member.java
+++ b/src/main/java/com/justdo/plug/blog/domain/member/Member.java
@@ -1,0 +1,17 @@
+package com.justdo.plug.blog.domain.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Member {
+
+    private String email;
+    private String nickname;
+    private String profile_url;
+}

--- a/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
@@ -1,0 +1,13 @@
+package com.justdo.plug.blog.domain.member;
+
+import com.justdo.plug.blog.global.config.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "member-service", url = "${application.config.members-url}", configuration = {
+    FeignConfig.class})
+public interface MemberClient {
+
+    @GetMapping
+    Member findMember();
+}

--- a/src/main/java/com/justdo/plug/blog/global/config/FeignConfig.java
+++ b/src/main/java/com/justdo/plug/blog/global/config/FeignConfig.java
@@ -1,0 +1,27 @@
+package com.justdo.plug.blog.global.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+
+                String authorizationHeader = request.getHeader("Authorization");
+                if (authorizationHeader != null) {
+                    requestTemplate.header("Authorization", authorizationHeader);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📌 요약

- 사용자 및 블로그 수정 정보 조회 API 구현
- Open Feign을 통해 auth-service와 연동

## 📝 상세 내용

- blog-service에서 블로그 정보 조회
- 사용자 정보는 open feign 통신을 통해 auth-service에게 응답 받아서 같이 전달하기
- Header에 Authorization 값에 액세스 토큰을 담아 전달하기

![image](https://github.com/DoTheZ-Team/blog-service/assets/103489352/44988825-7c7d-44aa-a2a8-f341d84faf95)


## 🗣️ 질문 및 이외 사항

- 하나의 서비스(blog-service)에서 다른 서비스(auth-service)에게 요청을 보낼 때 응답받는 값은 요청한 정보만 있는 DTO를 전달해야 값을 전달 받을 수 있을거 같아서 msa 안에서 연결되는 API들은 다르게 전달해줘야 할 것 같음

> 아니면 통일성을 위해서 다른 API도 전부 응답 DTO만 전달하는 형식으로 변경해도 좋을 것 같아 이야기 해봐야 될 것 같습니다.

![image](https://github.com/DoTheZ-Team/blog-service/assets/103489352/f2ea540d-2d31-4e4e-9ee3-32c25b503c04)


## ☑️ 이슈 번호

- close #
