### PR TITLE
Glue 121 - Feat : 블로그 구독 페이지 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/justdo/plug/blog/BlogApplication.java
+++ b/src/main/java/com/justdo/plug/blog/BlogApplication.java
@@ -2,12 +2,14 @@ package com.justdo.plug.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableDiscoveryClient
 public class BlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -63,8 +63,4 @@ public class BlogController {
         return ApiResponse.onSuccess(blogCommandService.createBlog(memberId));
     }
 
-    @GetMapping("/test/{blogId}")
-    public ApiResponse<BlogInfo> testBlog(@PathVariable(name = "blogId") Long blogId) {
-        return ApiResponse.onSuccess(blogQueryService.testBlogInfo(blogId));
-    }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -1,7 +1,6 @@
 package com.justdo.plug.blog.domain.blog.controller;
 
 import com.justdo.plug.blog.domain.blog.dto.BlogRequest;
-import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfo;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogProc;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -4,10 +4,14 @@ import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.member.MemberDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 public class BlogResponse {
 
@@ -94,4 +98,55 @@ public class BlogResponse {
             .createdAt(LocalDateTime.now())
             .build();
     }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogItem {
+
+        private Long blogId;
+        private String nickname;
+        private String title;
+        private String profile;
+    }
+
+    public static BlogItem toBlogItem(String nickname, Blog blog) {
+
+        return BlogItem.builder()
+            .blogId(blog.getId())
+            .nickname(nickname)
+            .title(blog.getTitle())
+            .profile(blog.getProfile())
+            .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogItemList {
+
+        private List<BlogItem> blogItems;
+        private boolean hasNext;
+        private boolean hasFirst;
+        private boolean hasLast;
+    }
+
+    public static BlogItemList toBlogItemList(List<String> nicknames, Slice<Blog> blogs) {
+
+        List<BlogItem> blogItems = IntStream.range(0,
+                Math.min(nicknames.size(), blogs.getContent().size()))
+            .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.getContent().get(i)))
+            .collect(Collectors.toList());
+
+        return BlogItemList.builder()
+            .blogItems(blogItems)
+            .hasNext(blogs.hasNext())
+            .hasFirst(blogs.isFirst())
+            .hasLast(blogs.isLast())
+            .build();
+    }
+
+
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -99,15 +99,23 @@ public class BlogResponse {
             .build();
     }
 
+    @Schema(description = "블로그 정보 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class BlogItem {
 
+        @Schema(description = "블로그 아이디")
         private Long blogId;
+
+        @Schema(description = "블로그 사용자의 닉네임")
         private String nickname;
+
+        @Schema(description = "블로그의 제목")
         private String title;
+
+        @Schema(description = "블로그 프로필")
         private String profile;
     }
 
@@ -121,15 +129,23 @@ public class BlogResponse {
             .build();
     }
 
+    @Schema(description = "블로그의 정보 목록 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class BlogItemList {
 
+        @Schema(description = "블로그 정보 목록")
         private List<BlogItem> blogItems;
+
+        @Schema(description = "추가 목록이 있는 지의 여부")
         private boolean hasNext;
+
+        @Schema(description = "첫 페이지인지의 여부")
         private boolean hasFirst;
+
+        @Schema(description = "마지막 페이지인지의 여부")
         private boolean hasLast;
     }
 

--- a/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
@@ -11,4 +11,9 @@ public interface BlogRepository extends JpaRepository<Blog, Long> {
 
     @Query("SELECT b FROM Blog b WHERE b.id in :blogIdList")
     Slice<Blog> findBlogIdList(List<Long> blogIdList, PageRequest pageRequest);
+
+    @Query("SELECT b FROM Blog b WHERE b.memberId in :memberIdList")
+    Slice<Blog> findSubscriberIdList(List<Long> memberIdList, PageRequest pageRequest);
+
+    Blog findByMemberId(Long memberId);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
@@ -1,8 +1,14 @@
 package com.justdo.plug.blog.domain.blog.repository;
 
 import com.justdo.plug.blog.domain.blog.Blog;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BlogRepository extends JpaRepository<Blog, Long> {
 
+    @Query("SELECT b FROM Blog b WHERE b.id in :blogIdList")
+    Slice<Blog> findBlogIdList(List<Long> blogIdList, PageRequest pageRequest);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -6,12 +6,19 @@ import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toBlogInfo;
 import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toMyBlogResult;
 
 import com.justdo.plug.blog.domain.blog.Blog;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
 import com.justdo.plug.blog.domain.blog.repository.BlogRepository;
 import com.justdo.plug.blog.domain.member.MemberClient;
 import com.justdo.plug.blog.domain.member.MemberDTO;
+import com.justdo.plug.blog.domain.subscription.service.SubscriptionQueryService;
 import com.justdo.plug.blog.global.exception.ApiException;
 import com.justdo.plug.blog.global.response.code.status.ErrorStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +29,7 @@ public class BlogQueryService {
 
     private final BlogRepository blogRepository;
     private final MemberClient memberClient;
+    private final SubscriptionQueryService subscriptionQueryService;
 
     public MyBlogResult getBlogInfo(Long blogId) {
 
@@ -34,18 +42,30 @@ public class BlogQueryService {
         return toMyBlogResult(memberDTOInfo, blogInfo);
     }
 
-    // test code / gateway 통신 확인용 추후 삭제
-    public BlogInfo testBlogInfo(Long blogId) {
-
-        // 나의 블로그 정보 조회
-        BlogInfo blogInfo = toBlogInfo(findById(blogId));
-
-        return blogInfo;
-    }
-
     public Blog findById(Long blogId) {
         return blogRepository.findById(blogId).orElseThrow(
             () -> new ApiException(ErrorStatus._BLOG_NOT_FOUND)
         );
     }
+
+    // 구독 페이지에서 내가 구독하는 or 나를 구독하는 블로그의 정보
+    public BlogItemList getBlogInfoList(Long memberId, int page) {
+
+        // 내가 구독한 블로그의 아이디 목록
+        List<Long> blogIdList = subscriptionQueryService.getSubscriptionBlogIdList(
+            memberId, page);
+
+        // 타블로그의 회원 목록
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+        Slice<Blog> blogs = blogRepository.findBlogIdList(blogIdList, pageRequest);
+
+        List<Long> memberIdList = blogs.stream()
+            .map(Blog::getMemberId)
+            .toList();
+        List<String> memberNicknames = memberClient.findMemberNicknames(memberIdList);
+
+        return BlogResponse.toBlogItemList(memberNicknames, blogs);
+
+    }
+
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -48,7 +48,7 @@ public class BlogQueryService {
         );
     }
 
-    // 구독 페이지에서 내가 구독하는 or 나를 구독하는 블로그의 정보
+    // 구독 페이지에서 내가 구독하는 블로그의 정보
     public BlogItemList getBlogInfoList(Long memberId, int page) {
 
         // 내가 구독한 블로그의 아이디 목록
@@ -66,6 +66,34 @@ public class BlogQueryService {
 
         return BlogResponse.toBlogItemList(memberNicknames, blogs);
 
+    }
+
+    // 구독 페이지에서 나를 구독하는 블로그의 정보
+    public BlogItemList getSubscriberBlogList(Long blogId, int page) {
+
+        // 나를 구독한 블로그의 사용자 아이디 목록
+        List<Long> subscriberIds = subscriptionQueryService.getSubscriberBlogIdList(blogId, page);
+
+        // 타블로그의 회원 목록
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+        Slice<Blog> blogs = blogRepository.findSubscriberIdList(subscriberIds, pageRequest);
+
+        List<String> memberNicknames = getMemberNicknames(blogs);
+
+        return BlogResponse.toBlogItemList(memberNicknames, blogs);
+
+    }
+
+    private List<String> getMemberNicknames(Slice<Blog> blogs) {
+
+        List<Long> memberIdList = blogs.stream()
+            .map(Blog::getMemberId)
+            .toList();
+        return memberClient.findMemberNicknames(memberIdList);
+    }
+
+    public Long findBlogIdByMemberId(Long memberId) {
+        return blogRepository.findByMemberId(memberId).getId();
     }
 
 }

--- a/src/main/java/com/justdo/plug/blog/domain/category/Category.java
+++ b/src/main/java/com/justdo/plug/blog/domain/category/Category.java
@@ -1,5 +1,0 @@
-package com.justdo.plug.blog.domain.category;
-
-public class Category {
-
-}

--- a/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
@@ -1,8 +1,10 @@
 package com.justdo.plug.blog.domain.member;
 
 import com.justdo.plug.blog.global.config.FeignConfig;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -15,4 +17,7 @@ public interface MemberClient {
 
     @PutMapping
     void updateMember(@RequestBody MemberDTO memberDTO);
+
+    @PostMapping("/blogs")
+    List<String> findMemberNicknames(@RequestBody List<Long> memberIdList);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
@@ -15,4 +15,7 @@ public interface PostClient {
 
     @PostMapping("/preview")
     PostItemList findSubscriptionFrom(@RequestBody List<Long> blogIdList, @RequestParam int page);
+
+    @PostMapping("/preview/subscribers")
+    PostItemList findSubscriptionTo(@RequestBody List<Long> memberIdList, @RequestParam int page);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
@@ -1,0 +1,18 @@
+package com.justdo.plug.blog.domain.post;
+
+import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
+import com.justdo.plug.blog.global.config.FeignConfig;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "post-service", url = "${application.config.posts-url}", configuration = {
+    FeignConfig.class})
+public interface PostClient {
+
+
+    @PostMapping("/preview")
+    PostItemList findSubscriptionFrom(@RequestBody List<Long> blogIdList, @RequestParam int page);
+}

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
@@ -1,0 +1,36 @@
+package com.justdo.plug.blog.domain.post;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class PostResponse {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class PostItem {
+
+        private Long postId;
+        private String title;
+        private String preview;
+        private String photo;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class PostItemList {
+
+        private List<PostItem> postItems;
+        private boolean hasNext;
+        private boolean hasFirst;
+        private boolean hasLast;
+    }
+
+}

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
@@ -1,5 +1,6 @@
 package com.justdo.plug.blog.domain.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,27 +10,43 @@ import lombok.NoArgsConstructor;
 
 public class PostResponse {
 
+    @Schema(description = "포스트 정보 DTO")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
     public static class PostItem {
 
+        @Schema(description = "포스트 아이디")
         private Long postId;
+
+        @Schema(description = "포스트 제목")
         private String title;
+
+        @Schema(description = "포스트 내용")
         private String preview;
+
+        @Schema(description = "포스트 메인 사진")
         private String photo;
     }
 
+    @Schema(description = "포스트 정보 목록 DTO")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
     public static class PostItemList {
 
+        @Schema(description = "포스트 정보 목록")
         private List<PostItem> postItems;
+
+        @Schema(description = "추가 목록이 있는 지의 여부")
         private boolean hasNext;
+
+        @Schema(description = "첫 페이지인지의 여부")
         private boolean hasFirst;
+
+        @Schema(description = "마지막 페이지인지의 여부")
         private boolean hasLast;
     }
 

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/Subscription.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/Subscription.java
@@ -24,9 +24,9 @@ public class Subscription extends BaseTimeEntity {
     @Builder.Default
     private boolean state = true;
 
-    private Long memberId;
+    private Long fromMemberId;
 
-    private Long blogId;
+    private Long toBlogId;
 
     /**
      * update

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -44,6 +44,8 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(subscriptionCommandService.subscribe(memberId, blogId));
     }
 
+    @Operation(summary = "내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionFrom(
         HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -58,4 +58,19 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
+
+    @GetMapping("/subscribers")
+    public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
+        HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+
+        BlogItemList blogInfoList = blogQueryService.getSubscriberBlogList(blogId, page);
+        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostTo(
+            blogId, page);
+
+        return ApiResponse.onSuccess(
+            SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
+    }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -1,7 +1,12 @@
 package com.justdo.plug.blog.domain.subscription.controller;
 
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
+import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
+import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
+import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse.SubscriptionProc;
 import com.justdo.plug.blog.domain.subscription.service.SubscriptionCommandService;
+import com.justdo.plug.blog.domain.subscription.service.SubscriptionQueryService;
 import com.justdo.plug.blog.global.response.ApiResponse;
 import com.justdo.plug.blog.global.utils.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,19 +15,23 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Subscription API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/blogs/subscription")
+@RequestMapping("/blogs/subscriptions")
 public class SubscriptionController {
 
     private final JwtProvider jwtProvider;
     private final SubscriptionCommandService subscriptionCommandService;
+    private final SubscriptionQueryService subscriptionQueryService;
+    private final BlogQueryService blogQueryService;
 
     @Operation(summary = "블로그 구독 요청 및 취소 요청", description = "다른 블로그를 구독 요청합니다. / 구독 상태에서 누르면 취소됩니다.")
     @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
@@ -33,5 +42,18 @@ public class SubscriptionController {
         Long memberId = jwtProvider.getUserIdFromToken(request);
 
         return ApiResponse.onSuccess(subscriptionCommandService.subscribe(memberId, blogId));
+    }
+
+    @GetMapping
+    public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionFrom(
+        HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        BlogItemList blogInfoList = blogQueryService.getBlogInfoList(memberId, page);
+        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostFrom(
+            memberId, page);
+
+        return ApiResponse.onSuccess(
+            SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -44,7 +44,7 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(subscriptionCommandService.subscribe(memberId, blogId));
     }
 
-    @Operation(summary = "내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
+    @Operation(summary = "내가 구독한 블로그와 포스트 정보 모두 조회", description = "내가 구독한 블로그와 포스트를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionFrom(
@@ -59,6 +59,8 @@ public class SubscriptionController {
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 
+    @Operation(summary = "내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/followers")
     public ApiResponse<BlogItemList> getFollowers(HttpServletRequest request,
         @RequestParam(defaultValue = "0") int page) {
@@ -67,6 +69,20 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(blogQueryService.getBlogInfoList(memberId, page));
     }
 
+    @Operation(summary = "내가 구독한 블로그의 포스트 정보 조회", description = "내가 구독한 블로그의 포스트 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
+    @GetMapping("/followers/posts")
+    public ApiResponse<PostItemList> getFollowersPosts(HttpServletRequest request,
+        @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        return ApiResponse.onSuccess(
+            subscriptionQueryService.getSubscriptionPostFrom(memberId, page));
+    }
+
+
+    @Operation(summary = "나를 구독한 블로그와 포스트 모두 정보 조회", description = "나를 구독한 블로그와 포스트 정보를 모두 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/subscribers")
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
         HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
@@ -82,6 +98,8 @@ public class SubscriptionController {
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 
+    @Operation(summary = "나를 구독한 블로그 정보 조회", description = "나를 구독한 블로그 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/follows")
     public ApiResponse<BlogItemList> getFollows(HttpServletRequest request,
         @RequestParam(defaultValue = "0") int page) {
@@ -90,5 +108,18 @@ public class SubscriptionController {
         Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
 
         return ApiResponse.onSuccess(blogQueryService.getSubscriberBlogList(blogId, page));
+    }
+
+    @Operation(summary = "나를 구독한 블로그의 포스트 정보 조회", description = "나를 구독한 블로그의 포스트 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
+    @GetMapping("/follows/posts")
+    public ApiResponse<PostItemList> getFollowsPosts(HttpServletRequest request,
+        @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+
+        return ApiResponse.onSuccess(subscriptionQueryService.getSubscriptionPostTo(
+            blogId, page));
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -59,6 +59,14 @@ public class SubscriptionController {
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 
+    @GetMapping("/followers")
+    public ApiResponse<BlogItemList> getFollowers(HttpServletRequest request,
+        @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        return ApiResponse.onSuccess(blogQueryService.getBlogInfoList(memberId, page));
+    }
+
     @GetMapping("/subscribers")
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
         HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
@@ -72,5 +80,15 @@ public class SubscriptionController {
 
         return ApiResponse.onSuccess(
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
+    }
+
+    @GetMapping("/follows")
+    public ApiResponse<BlogItemList> getFollows(HttpServletRequest request,
+        @RequestParam(defaultValue = "0") int page) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+
+        return ApiResponse.onSuccess(blogQueryService.getSubscriberBlogList(blogId, page));
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
@@ -1,6 +1,11 @@
 package com.justdo.plug.blog.domain.subscription.dto;
 
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
+import com.justdo.plug.blog.domain.post.PostResponse;
+import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
 import com.justdo.plug.blog.domain.subscription.Subscription;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,13 +14,17 @@ import lombok.NoArgsConstructor;
 
 public class SubscriptionResponse {
 
+    @Schema(description = "구독 요청 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class SubscriptionProc {
 
+        @Schema(description = "구독 고유 아이디")
         private Long subscriptionId;
+
+        @Schema(description = "응답 처리 시간")
         private LocalDateTime createdAt;
     }
 
@@ -30,8 +39,27 @@ public class SubscriptionResponse {
     public static Subscription toEntity(Long memberId, Long blogId) {
 
         return Subscription.builder()
-            .memberId(memberId)
-            .blogId(blogId)
+            .fromMemberId(memberId)
+            .toBlogId(blogId)
+            .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class SubscriptionResult {
+
+        BlogResponse.BlogItemList blogItemList;
+        PostResponse.PostItemList postItemList;
+    }
+
+    public static SubscriptionResult toSubscriptionResult(BlogItemList blogItemList,
+        PostItemList postItemList) {
+
+        return SubscriptionResult.builder()
+            .blogItemList(blogItemList)
+            .postItemList(postItemList)
             .build();
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
@@ -44,6 +44,7 @@ public class SubscriptionResponse {
             .build();
     }
 
+    @Schema(description = "내가 구독한 블로그의 정보 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
@@ -10,7 +10,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     Optional<Subscription> findByFromMemberIdAndToBlogId(Long fromMemberId, Long toBlogId);
 
-    List<Subscription> findAllByFromMemberId(Long fromMemberId, PageRequest pageRequest);
+    List<Subscription> findAllByFromMemberIdAndStateIsTrue(Long fromMemberId, PageRequest pageRequest);
 
-    List<Subscription> findAllByToBlogId(Long toBlogId, PageRequest pageRequest);
+    List<Subscription> findAllByToBlogIdAndStateIsTrue(Long toBlogId, PageRequest pageRequest);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
@@ -11,4 +11,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     Optional<Subscription> findByFromMemberIdAndToBlogId(Long fromMemberId, Long toBlogId);
 
     List<Subscription> findAllByFromMemberId(Long fromMemberId, PageRequest pageRequest);
+
+    List<Subscription> findAllByToBlogId(Long toBlogId, PageRequest pageRequest);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
@@ -1,10 +1,14 @@
 package com.justdo.plug.blog.domain.subscription.repository;
 
 import com.justdo.plug.blog.domain.subscription.Subscription;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
-    Optional<Subscription> findByMemberIdAndBlogId(Long memberId, Long blogId);
+    Optional<Subscription> findByFromMemberIdAndToBlogId(Long fromMemberId, Long toBlogId);
+
+    List<Subscription> findAllByFromMemberId(Long fromMemberId, PageRequest pageRequest);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionCommandService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionCommandService.java
@@ -38,6 +38,6 @@ public class SubscriptionCommandService {
     }
 
     public Optional<Subscription> getSubscription(Long memberId, Long blogId) {
-        return subscriptionRepository.findByMemberIdAndBlogId(memberId, blogId);
+        return subscriptionRepository.findByFromMemberIdAndToBlogId(memberId, blogId);
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -26,6 +26,15 @@ public class SubscriptionQueryService {
         return postClient.findSubscriptionFrom(blogIdList, page);
     }
 
+    // 나를 구독하는 블로그의 포스트 정보 조회
+    public PostItemList getSubscriptionPostTo(Long blogId, int page) {
+
+        List<Long> subscriberIdList = getSubscriberBlogIdList(blogId, page);
+
+        return postClient.findSubscriptionTo(subscriberIdList, page);
+    }
+
+    // 내가 구독하는 블로그 사용자의 아이디 목록 조회
     public List<Long> getSubscriptionBlogIdList(Long memberId, int page) {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
@@ -34,5 +43,16 @@ public class SubscriptionQueryService {
             .stream()
             .map(Subscription::getToBlogId)
             .toList();
+    }
+
+    // 나를 구독하는 블로그 사용자의 아이디 목록 조회
+    public List<Long> getSubscriberBlogIdList(Long blogId, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+        return subscriptionRepository.findAllByToBlogId(blogId, pageRequest)
+            .stream()
+            .map(Subscription::getFromMemberId)
+            .toList();
+
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -1,0 +1,38 @@
+package com.justdo.plug.blog.domain.subscription.service;
+
+import com.justdo.plug.blog.domain.post.PostClient;
+import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
+import com.justdo.plug.blog.domain.subscription.Subscription;
+import com.justdo.plug.blog.domain.subscription.repository.SubscriptionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionQueryService {
+
+    private final PostClient postClient;
+    private final SubscriptionRepository subscriptionRepository;
+
+    public PostItemList getSubscriptionPostFrom(Long memberId, int page) {
+
+        List<Long> blogIdList = getSubscriptionBlogIdList(memberId, page);
+
+        return postClient.findSubscriptionFrom(blogIdList, page);
+    }
+
+    public List<Long> getSubscriptionBlogIdList(Long memberId, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+
+        return subscriptionRepository.findAllByFromMemberId(memberId, pageRequest)
+            .stream()
+            .map(Subscription::getToBlogId)
+            .toList();
+    }
+}

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -39,7 +39,7 @@ public class SubscriptionQueryService {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
 
-        return subscriptionRepository.findAllByFromMemberId(memberId, pageRequest)
+        return subscriptionRepository.findAllByFromMemberIdAndStateIsTrue(memberId, pageRequest)
             .stream()
             .map(Subscription::getToBlogId)
             .toList();
@@ -49,7 +49,7 @@ public class SubscriptionQueryService {
     public List<Long> getSubscriberBlogIdList(Long blogId, int page) {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
-        return subscriptionRepository.findAllByToBlogId(blogId, pageRequest)
+        return subscriptionRepository.findAllByToBlogIdAndStateIsTrue(blogId, pageRequest)
             .stream()
             .map(Subscription::getFromMemberId)
             .toList();


### PR DESCRIPTION
## 📌 요약

- 블로그 구독 페이지 조회 API 구현

## 📝 상세 내용

- 내가 구독한 블로그 조회 API 구현
- 내가 구독한 블로그의 팔로워 정보만 조회 API 구현
- 내가 구독한 블로그의 포스트 정보만 조회 API 구현
###
- 나를 구독한 블로그 조회 API 구현
- 나를 구독한 블로그의 팔로우 정보만 조회 API 구현
- 나를 구독한 블로그의 팔로우 정보만 조회 API 구현

## 🗣️ 질문 및 이외 사항

<img width="691" alt="image" src="https://github.com/DoTheZ-Team/blog-service/assets/103489352/8f4c42b6-d354-45a6-bb96-fc5030124ce9">

> - 왼쪽 컴포넌트와 오른쪽 컴포넌트를 분리해서 페이징을 적용해야 하므로, API를 각각 요청해야함
> - 처음 접속할 때는 두 컴포넌트 정보를 같이 전달해주는 식으로 했는데, 월요일에 프론트와 상의 후 결정 @yeyounging 

<img width="703" alt="image" src="https://github.com/DoTheZ-Team/blog-service/assets/103489352/4a14c1fd-c7f4-49bb-bcc2-027bfcbb8f9a">


## ☑️ 이슈 번호

- close #
