### PR TITLE
Glue 292 Feat: 블로그 페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -2,6 +2,7 @@ package com.justdo.plug.blog.domain.blog.controller;
 
 import com.justdo.plug.blog.domain.blog.dto.BlogRequest;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfoList;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogPage;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogProc;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;
@@ -10,7 +11,6 @@ import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
 import com.justdo.plug.blog.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -35,37 +35,44 @@ public class BlogController {
     private final BlogCommandService blogCommandService;
     private final BlogQueryService blogQueryService;
 
-    @Operation(summary = "블로그 이미지 업로드", description = "블로그의 프로필 & 배경사진 이미지를 업로드합니다.")
-    @PostMapping("/images")
-    public ApiResponse<ImageResult> uploadImage(
-        @RequestPart(name = "imageUrl") MultipartFile multipartFile) {
-        return ApiResponse.onSuccess(blogCommandService.imageUpload(multipartFile));
-    }
-
-    @Operation(summary = "사용자 및 블로그 정보 조회", description = "사용자 및 블로그 개인 정보를 조회합니다.")
-    @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @GetMapping("/mypage/{blogId}")
-    public ApiResponse<MyBlogResult> myBlog(@PathVariable(name = "blogId") Long blogId) {
-        return ApiResponse.onSuccess(blogQueryService.getBlogInfo(blogId));
-    }
-
-    @Operation(summary = "사용자 및 블로그 정보 수정", description = "사용자 및 블로그 정보를 수정합니다.")
-    @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @PatchMapping("/{blogId}")
-    public ApiResponse<BlogProc> updateBlog(@RequestBody BlogRequest request,
-        @PathVariable(name = "blogId") Long blogId) {
-
-        return ApiResponse.onSuccess(blogCommandService.updateBlog(request, blogId));
-    }
-
-    @Operation(summary = "블로그 생성 요청", description = "사용자 회원가입 시 자동으로 하나의 블로그가 생성됩니다.")
+    @Operation(summary = "블로그 생성을 요청합니다.", description = "사용자 회원가입 시 자동으로 하나의 블로그가 생성됩니다.")
     @PostMapping
     public ApiResponse<BlogProc> createBlog(@RequestParam Long memberId) {
 
         return ApiResponse.onSuccess(blogCommandService.createBlog(memberId));
     }
 
-    @Operation(summary = "게시글 검색 후 해당 블로그 보기 요청", description = "검색한 게시글의 블로그 정보를 조회합니다.")
+    @Operation(summary = "블로그 페이지를 조회합니다.", description = "Blog 정보, 최신 4개의 Post, MemberName을 반환합니다.")
+    @GetMapping("/{blogId}")
+    public ApiResponse<BlogPage> getBlogPage(@PathVariable Long blogId) {
+
+        return ApiResponse.onSuccess(blogQueryService.findBlogPage(blogId));
+    }
+
+    @Operation(summary = "사용자 및 블로그 정보를 조회합니다.", description = "사용자 및 블로그 개인 정보를 조회합니다.")
+    @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @GetMapping("/mypage/{blogId}")
+    public ApiResponse<MyBlogResult> myBlog(@PathVariable(name = "blogId") Long blogId) {
+        return ApiResponse.onSuccess(blogQueryService.getBlogInfo(blogId));
+    }
+
+    @Operation(summary = "사용자 및 블로그 정보를 수정합니다.", description = "사용자 및 블로그 정보를 수정합니다.")
+    @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @PatchMapping("/mypage/{blogId}")
+    public ApiResponse<BlogProc> updateBlog(@RequestBody BlogRequest request,
+        @PathVariable(name = "blogId") Long blogId) {
+
+        return ApiResponse.onSuccess(blogCommandService.updateBlog(request, blogId));
+    }
+
+    @Operation(summary = "Glue Service에서 사용하는 이미지 업로드 API 입니다.", description = "Blog, Post, Member 서버에서 이미지 업로드 시 사용합니다.")
+    @PostMapping("/images")
+    public ApiResponse<ImageResult> uploadImage(
+        @RequestPart(name = "imageUrl") MultipartFile multipartFile) {
+        return ApiResponse.onSuccess(blogCommandService.imageUpload(multipartFile));
+    }
+
+    @Operation(summary = "게시글 검색 후 '블로그 보기'를 요청합니다.", description = "검색한 게시글의 블로그 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이징 번호", example = "0", in = ParameterIn.QUERY)
     @PostMapping("/search")
     public BlogInfoList searchBlog(@RequestBody List<Long> blogIdList,

--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -35,28 +35,28 @@ public class BlogController {
     private final BlogCommandService blogCommandService;
     private final BlogQueryService blogQueryService;
 
-    @Operation(summary = "블로그 생성을 요청합니다.", description = "사용자 회원가입 시 자동으로 하나의 블로그가 생성됩니다.")
+    @Operation(summary = "회원 가입 - 회원 가입 시 자동으로 블로그 생성을 요청합니다.", description = "Open feign 요청 / 사용자 회원가입 시 자동으로 하나의 블로그가 생성됩니다.")
     @PostMapping
     public ApiResponse<BlogProc> createBlog(@RequestParam Long memberId) {
 
         return ApiResponse.onSuccess(blogCommandService.createBlog(memberId));
     }
 
-    @Operation(summary = "블로그 페이지를 조회합니다.", description = "Blog 정보, 최신 4개의 Post, MemberName을 반환합니다.")
+    @Operation(summary = "블로그 페이지 - 블로그 페이지를 조회합니다.", description = "Blog 정보, 최신 4개의 Post, MemberName을 반환합니다.")
     @GetMapping("/{blogId}")
     public ApiResponse<BlogPage> getBlogPage(@PathVariable Long blogId) {
 
         return ApiResponse.onSuccess(blogQueryService.findBlogPage(blogId));
     }
 
-    @Operation(summary = "사용자 및 블로그 정보를 조회합니다.", description = "사용자 및 블로그 개인 정보를 조회합니다.")
+    @Operation(summary = "마이 페이지 - 사용자 및 블로그 정보를 조회합니다.", description = "마이페이지에 보여줄 사용자 및 블로그 개인 정보를 조회합니다.")
     @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/mypage/{blogId}")
     public ApiResponse<MyBlogResult> myBlog(@PathVariable(name = "blogId") Long blogId) {
         return ApiResponse.onSuccess(blogQueryService.getBlogInfo(blogId));
     }
 
-    @Operation(summary = "사용자 및 블로그 정보를 수정합니다.", description = "사용자 및 블로그 정보를 수정합니다.")
+    @Operation(summary = "마이 페이지 - 사용자 및 블로그 정보를 수정합니다.", description = "마이페이지에서 사용자 및 블로그 정보를 수정합니다.")
     @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PatchMapping("/mypage/{blogId}")
     public ApiResponse<BlogProc> updateBlog(@RequestBody BlogRequest request,
@@ -65,14 +65,14 @@ public class BlogController {
         return ApiResponse.onSuccess(blogCommandService.updateBlog(request, blogId));
     }
 
-    @Operation(summary = "Glue Service에서 사용하는 이미지 업로드 API 입니다.", description = "Blog, Post, Member 서버에서 이미지 업로드 시 사용합니다.")
+    @Operation(summary = "이미지 업로드 API - Glue Service에서 사용하는 이미지 업로드 API 입니다.", description = "Blog, Post, Member 서버에서 이미지 업로드 시 사용합니다.")
     @PostMapping("/images")
     public ApiResponse<ImageResult> uploadImage(
         @RequestPart(name = "imageUrl") MultipartFile multipartFile) {
         return ApiResponse.onSuccess(blogCommandService.imageUpload(multipartFile));
     }
 
-    @Operation(summary = "게시글 검색 후 '블로그 보기'를 요청합니다.", description = "검색한 게시글의 블로그 정보를 조회합니다.")
+    @Operation(summary = "검색 페이지 - 게시글 검색 후 '블로그 보기'를 요청합니다.", description = "검색한 게시글의 블로그 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이징 번호", example = "0", in = ParameterIn.QUERY)
     @PostMapping("/search")
     public BlogInfoList searchBlog(@RequestBody List<Long> blogIdList,

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -2,6 +2,7 @@ package com.justdo.plug.blog.domain.blog.dto;
 
 import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.member.MemberDTO;
+import com.justdo.plug.blog.domain.post.PostResponse.BlogPostItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -204,6 +205,27 @@ public class BlogResponse {
             .hasNext(blogs.hasNext())
             .hasFirst(blogs.isFirst())
             .hasLast(blogs.isLast())
+            .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogPage {
+
+        private BlogInfo blogInfo;
+        private BlogPostItem blogPostItem;
+        private String memberName;
+    }
+
+    public static BlogPage toBlogpage(BlogInfo blogInfo, BlogPostItem blogPostItem,
+        String memberName) {
+
+        return BlogPage.builder()
+            .blogInfo(blogInfo)
+            .blogPostItem(blogPostItem)
+            .memberName(memberName)
             .build();
     }
 

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -3,15 +3,19 @@ package com.justdo.plug.blog.domain.blog.service;
 import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfo;
 import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;
 import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toBlogInfo;
+import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toBlogpage;
 import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toMyBlogResult;
 
 import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfoList;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogPage;
 import com.justdo.plug.blog.domain.blog.repository.BlogRepository;
 import com.justdo.plug.blog.domain.member.MemberClient;
 import com.justdo.plug.blog.domain.member.MemberDTO;
+import com.justdo.plug.blog.domain.post.PostClient;
+import com.justdo.plug.blog.domain.post.PostResponse.BlogPostItem;
 import com.justdo.plug.blog.domain.subscription.service.SubscriptionQueryService;
 import com.justdo.plug.blog.global.exception.ApiException;
 import com.justdo.plug.blog.global.response.code.status.ErrorStatus;
@@ -30,8 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class BlogQueryService {
 
     private final BlogRepository blogRepository;
-    private final MemberClient memberClient;
     private final SubscriptionQueryService subscriptionQueryService;
+    private final MemberClient memberClient;
+    private final PostClient postClient;
 
     public MyBlogResult getBlogInfo(Long blogId) {
 
@@ -110,4 +115,14 @@ public class BlogQueryService {
         return BlogResponse.toBlogInfoList(blogList);
     }
 
+    public BlogPage findBlogPage(Long blogId) {
+
+        Blog blog = findById(blogId);
+
+        BlogInfo blogInfo = toBlogInfo(blog);
+        BlogPostItem blogPostItem = postClient.findBlogPostItem(blogId);
+        String memberName = memberClient.findMemberName(blog.getMemberId());
+
+        return toBlogpage(blogInfo, blogPostItem, memberName);
+    }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/member/MemberClient.java
@@ -4,6 +4,7 @@ import com.justdo.plug.blog.global.config.FeignConfig;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,9 @@ public interface MemberClient {
 
     @GetMapping
     MemberDTO findMember();
+
+    @GetMapping("/blogs/{memberId}")
+    String findMemberName(@PathVariable Long memberId);
 
     @PutMapping
     void updateMember(@RequestBody MemberDTO memberDTO);

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
@@ -1,9 +1,12 @@
 package com.justdo.plug.blog.domain.post;
 
+import com.justdo.plug.blog.domain.post.PostResponse.BlogPostItem;
 import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
 import com.justdo.plug.blog.global.config.FeignConfig;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,4 +21,7 @@ public interface PostClient {
 
     @PostMapping("/preview/subscribers")
     PostItemList findSubscriptionTo(@RequestBody List<Long> memberIdList, @RequestParam int page);
+
+    @GetMapping("/blogs/{blogId}")
+    BlogPostItem findBlogPostItem(@PathVariable Long blogId);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostClient.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface PostClient {
 
 
-    @PostMapping("/preview")
+    @PostMapping("/preview/subscriptions")
     PostItemList findSubscriptionFrom(@RequestBody List<Long> blogIdList, @RequestParam int page);
 
     @PostMapping("/preview/subscribers")

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
@@ -50,4 +50,14 @@ public class PostResponse {
         private boolean hasLast;
     }
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class BlogPostItem {
+
+        private List<PostItem> postItems;
+        private List<String> hashtagNames;
+    }
+
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -33,7 +33,7 @@ public class SubscriptionController {
     private final SubscriptionQueryService subscriptionQueryService;
     private final BlogQueryService blogQueryService;
 
-    @Operation(summary = "블로그 구독 요청 및 취소 요청", description = "다른 블로그를 구독 요청합니다. / 구독 상태에서 누르면 취소됩니다.")
+    @Operation(summary = "블로그 페이지 - 블로그 구독 요청 및 취소 요청", description = "다른 블로그를 구독 요청합니다. / 구독 상태에서 누르면 취소됩니다.")
     @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PostMapping("/{blogId}")
     public ApiResponse<SubscriptionProc> subscribe(HttpServletRequest request,
@@ -44,7 +44,7 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(subscriptionCommandService.subscribe(memberId, blogId));
     }
 
-    @Operation(summary = "내가 구독한 블로그와 포스트 정보 모두 조회", description = "내가 구독한 블로그와 포스트를 조회합니다.")
+    @Operation(summary = "구독 페이지 - 내가 구독한 블로그와 포스트 정보 모두 조회", description = "내가 구독한 블로그와 포스트를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionFrom(
@@ -59,7 +59,7 @@ public class SubscriptionController {
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 
-    @Operation(summary = "내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
+    @Operation(summary = "구독 페이지 - 내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/followers")
     public ApiResponse<BlogItemList> getFollowers(HttpServletRequest request,
@@ -69,7 +69,7 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(blogQueryService.getBlogInfoList(memberId, page));
     }
 
-    @Operation(summary = "내가 구독한 블로그의 포스트 정보 조회", description = "내가 구독한 블로그의 포스트 정보를 조회합니다.")
+    @Operation(summary = "구독 페이지 - 내가 구독한 블로그의 포스트 정보 조회", description = "내가 구독한 블로그의 포스트 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/followers/posts")
     public ApiResponse<PostItemList> getFollowersPosts(HttpServletRequest request,
@@ -81,7 +81,7 @@ public class SubscriptionController {
     }
 
 
-    @Operation(summary = "나를 구독한 블로그와 포스트 모두 정보 조회", description = "나를 구독한 블로그와 포스트 정보를 모두 조회합니다.")
+    @Operation(summary = "구독 페이지 - 나를 구독한 블로그와 포스트 모두 정보 조회", description = "나를 구독한 블로그와 포스트 정보를 모두 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/subscribers")
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
@@ -98,7 +98,7 @@ public class SubscriptionController {
             SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
     }
 
-    @Operation(summary = "나를 구독한 블로그 정보 조회", description = "나를 구독한 블로그 정보를 조회합니다.")
+    @Operation(summary = "구독 페이지 - 나를 구독한 블로그 정보 조회", description = "나를 구독한 블로그 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/follows")
     public ApiResponse<BlogItemList> getFollows(HttpServletRequest request,
@@ -110,7 +110,7 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(blogQueryService.getSubscriberBlogList(blogId, page));
     }
 
-    @Operation(summary = "나를 구독한 블로그의 포스트 정보 조회", description = "나를 구독한 블로그의 포스트 정보를 조회합니다.")
+    @Operation(summary = "구독 페이지 - 나를 구독한 블로그의 포스트 정보 조회", description = "나를 구독한 블로그의 포스트 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/follows/posts")
     public ApiResponse<PostItemList> getFollowsPosts(HttpServletRequest request,


### PR DESCRIPTION
## 📌 요약

- 블로그 페이지 조회 API 구현

## 📝 상세 내용

- memberName은 auth-server에게 요청합니다.
- 최신 Post 4개는 post-server에게 요청합니다.

## 🗣️ 질문 및 이외 사항

![image](https://github.com/DoTheZ-Team/blog-service/assets/103489352/b2b278b6-9544-42cc-af0c-c0f509903d24)


## ☑️ 이슈 번호

- close #
