### PR TITLE
Fix: 내가 구독한 블로그의 포스트 조회 시 정보 추가 전달 및 로그인한 사용자 기준 블로그 구독 여부 API 구현

### DIFF
--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -30,9 +30,9 @@ public class BlogResponse {
 
     public static MyBlogResult toMyBlogResult(MemberDTO memberDTOInfo, BlogInfo blogInfo) {
         return MyBlogResult.builder()
-            .memberDTOInfo(memberDTOInfo)
-            .blogInfo(blogInfo)
-            .build();
+                .memberDTOInfo(memberDTOInfo)
+                .blogInfo(blogInfo)
+                .build();
     }
 
     @Schema(description = "블로그 정보 응답 DTO")
@@ -58,11 +58,11 @@ public class BlogResponse {
     public static BlogInfo toBlogInfo(Blog blog) {
 
         return BlogInfo.builder()
-            .title(blog.getTitle())
-            .description(blog.getDescription())
-            .profile(blog.getProfile())
-            .background(blog.getBackground())
-            .build();
+                .title(blog.getTitle())
+                .description(blog.getDescription())
+                .profile(blog.getProfile())
+                .background(blog.getBackground())
+                .build();
     }
 
     @Schema(description = "블로그 정보 응답 페이징 DTO")
@@ -94,17 +94,17 @@ public class BlogResponse {
     public static BlogInfoList toBlogInfoList(Page<Blog> blogs) {
 
         List<BlogInfo> blogInfoList = blogs.getContent()
-            .stream()
-            .map(BlogResponse::toBlogInfo)
-            .toList();
+                .stream()
+                .map(BlogResponse::toBlogInfo)
+                .toList();
 
         return BlogInfoList.builder()
-            .blogInfoList(blogInfoList)
-            .listSize(blogInfoList.size())
-            .totalPage(blogs.getTotalPages())
-            .isFirst(blogs.isFirst())
-            .isLast(blogs.isLast())
-            .build();
+                .blogInfoList(blogInfoList)
+                .listSize(blogInfoList.size())
+                .totalPage(blogs.getTotalPages())
+                .isFirst(blogs.isFirst())
+                .isLast(blogs.isLast())
+                .build();
     }
 
     @Schema(description = "이미지 응답 DTO")
@@ -138,9 +138,9 @@ public class BlogResponse {
     public static BlogProc toBlogProc(Long blogId) {
 
         return BlogProc.builder()
-            .blogId(blogId)
-            .createdAt(LocalDateTime.now())
-            .build();
+                .blogId(blogId)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 
     @Schema(description = "구독 페이지 블로그 정보 DTO")
@@ -166,11 +166,11 @@ public class BlogResponse {
     public static BlogItem toBlogItem(String nickname, Blog blog) {
 
         return BlogItem.builder()
-            .blogId(blog.getId())
-            .nickname(nickname)
-            .title(blog.getTitle())
-            .profile(blog.getProfile())
-            .build();
+                .blogId(blog.getId())
+                .nickname(nickname)
+                .title(blog.getTitle())
+                .profile(blog.getProfile())
+                .build();
     }
 
     @Schema(description = "구독 페이지 블로그의 정보 목록 DTO")
@@ -184,28 +184,36 @@ public class BlogResponse {
         private List<BlogItem> blogItems;
 
         @Schema(description = "추가 목록이 있는 지의 여부")
-        private boolean hasNext;
+        private Boolean hasNext;
 
         @Schema(description = "첫 페이지인지의 여부")
-        private boolean hasFirst;
+        private Boolean isFirst;
 
         @Schema(description = "마지막 페이지인지의 여부")
-        private boolean hasLast;
+        private Boolean isLast;
     }
 
     public static BlogItemList toBlogItemList(List<String> nicknames, Slice<Blog> blogs) {
 
         List<BlogItem> blogItems = IntStream.range(0,
-                Math.min(nicknames.size(), blogs.getContent().size()))
-            .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.getContent().get(i)))
-            .collect(Collectors.toList());
+                        Math.min(nicknames.size(), blogs.getContent().size()))
+                .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.getContent().get(i)))
+                .collect(Collectors.toList());
 
         return BlogItemList.builder()
-            .blogItems(blogItems)
-            .hasNext(blogs.hasNext())
-            .hasFirst(blogs.isFirst())
-            .hasLast(blogs.isLast())
-            .build();
+                .blogItems(blogItems)
+                .hasNext(blogs.hasNext())
+                .isFirst(blogs.isFirst())
+                .isLast(blogs.isLast())
+                .build();
+    }
+
+    public static List<BlogItem> toBlogItems(List<String> nicknames, List<Blog> blogs) {
+
+        return IntStream.range(0, blogs.size())
+                .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.get(i)))
+                .toList();
+
     }
 
     @Builder
@@ -220,13 +228,13 @@ public class BlogResponse {
     }
 
     public static BlogPage toBlogpage(BlogInfo blogInfo, BlogPostItem blogPostItem,
-        String memberName) {
+            String memberName) {
 
         return BlogPage.builder()
-            .blogInfo(blogInfo)
-            .blogPostItem(blogPostItem)
-            .memberName(memberName)
-            .build();
+                .blogInfo(blogInfo)
+                .blogPostItem(blogPostItem)
+                .memberName(memberName)
+                .build();
     }
 
 

--- a/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
@@ -20,4 +20,7 @@ public interface BlogRepository extends JpaRepository<Blog, Long> {
 
     @Query("SELECT b FROM Blog b WHERE b.id IN :blogIdList")
     Page<Blog> findAllByBlogList(List<Long> blogIdList, PageRequest pageRequest);
+
+    @Query("SELECT b FROM Blog b WHERE b.id IN :blogIdList")
+    List<Blog> findAllByBlogs(List<Long> blogIdList);
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -9,6 +9,7 @@ import static com.justdo.plug.blog.domain.blog.dto.BlogResponse.toMyBlogResult;
 import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfoList;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItem;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogPage;
 import com.justdo.plug.blog.domain.blog.repository.BlogRepository;
@@ -73,6 +74,20 @@ public class BlogQueryService {
 
         return BlogResponse.toBlogItemList(memberNicknames, blogs);
 
+    }
+
+    /** 구독 페이지 - 내가 구독한 블로그의 포스트 정보 전달 시 블로그 정보 추가 전달**/
+    public List<BlogItem> getPostOfBlogInfoList(List<Long> blogIdList) {
+
+        List<Blog> blogList = blogRepository.findAllByBlogs(blogIdList);
+
+        List<Long> memberIdList = blogList.stream()
+                .map(Blog::getMemberId)
+                .toList();
+
+        List<String> memberNicknames = memberClient.findMemberNicknames(memberIdList);
+
+        return BlogResponse.toBlogItems(memberNicknames, blogList);
     }
 
     // 구독 페이지에서 나를 구독하는 블로그의 정보

--- a/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/post/PostResponse.java
@@ -17,6 +17,9 @@ public class PostResponse {
     @Builder
     public static class PostItem {
 
+        @Schema(description = "블로그 아이디")
+        private Long blogId;
+
         @Schema(description = "포스트 아이디")
         private Long postId;
 

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -1,9 +1,12 @@
 package com.justdo.plug.blog.domain.subscription.controller;
 
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItem;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
 import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
 import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
+import com.justdo.plug.blog.domain.subscription.dto.SubscriptionRequest;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse;
+import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse.BlogPostItem;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse.SubscriptionProc;
 import com.justdo.plug.blog.domain.subscription.service.SubscriptionCommandService;
 import com.justdo.plug.blog.domain.subscription.service.SubscriptionQueryService;
@@ -14,10 +17,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,7 +42,7 @@ public class SubscriptionController {
     @Parameter(name = "blogId", description = "블로그 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PostMapping("/{blogId}")
     public ApiResponse<SubscriptionProc> subscribe(HttpServletRequest request,
-        @PathVariable(name = "blogId") Long blogId) {
+            @PathVariable(name = "blogId") Long blogId) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
 
@@ -48,22 +53,30 @@ public class SubscriptionController {
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionFrom(
-        HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
+            HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        BlogItemList blogInfoList = blogQueryService.getBlogInfoList(memberId, page);
+
+        /** 왼쪽 구독한 블로그 정보 **/
+        BlogItemList blogItemList = blogQueryService.getBlogInfoList(memberId, page);
+
+        /** 오른쪽 구독한 블로그의 포스트 정보**/
         PostItemList postItemList = subscriptionQueryService.getSubscriptionPostFrom(
-            memberId, page);
+                memberId, page);
+        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<BlogItem> blogItems = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
+        BlogPostItem blogPostItem = SubscriptionResponse.toBlogPostItem(postItemList,
+                blogItems);
 
         return ApiResponse.onSuccess(
-            SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
+                SubscriptionResponse.toSubscriptionResult(blogItemList, blogPostItem));
     }
 
     @Operation(summary = "구독 페이지 - 내가 구독한 블로그 정보 조회", description = "내가 구독한 블로그의 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/follows")
-    public ApiResponse<BlogItemList> getFollowers(HttpServletRequest request,
-        @RequestParam(defaultValue = "0") int page) {
+    public ApiResponse<BlogItemList> getFollows(HttpServletRequest request,
+            @RequestParam(defaultValue = "0") int page) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
         return ApiResponse.onSuccess(blogQueryService.getBlogInfoList(memberId, page));
@@ -72,54 +85,65 @@ public class SubscriptionController {
     @Operation(summary = "구독 페이지 - 내가 구독한 블로그의 포스트 정보 조회", description = "내가 구독한 블로그의 포스트 정보를 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/follows/posts")
-    public ApiResponse<PostItemList> getFollowersPosts(HttpServletRequest request,
-        @RequestParam(defaultValue = "0") int page) {
+    public ApiResponse<BlogPostItem> getFollowsPosts(HttpServletRequest request,
+            @RequestParam(defaultValue = "0") int page) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        return ApiResponse.onSuccess(
-            subscriptionQueryService.getSubscriptionPostFrom(memberId, page));
-    }
-
-
-    @Operation(summary = "구독 페이지 - 나를 구독한 블로그와 포스트 모두 정보 조회", description = "나를 구독한 블로그와 포스트 정보를 모두 조회합니다.")
-    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
-    @GetMapping("/subscribers")
-    public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
-        HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
-
-        Long memberId = jwtProvider.getUserIdFromToken(request);
-        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
-
-        BlogItemList blogInfoList = blogQueryService.getSubscriberBlogList(blogId, page);
-        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostTo(
-            blogId, page);
+        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostFrom(
+                memberId, page);
+        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<BlogItem> blogItemList = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
 
         return ApiResponse.onSuccess(
-            SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
+                SubscriptionResponse.toBlogPostItem(postItemList, blogItemList));
     }
 
-    @Operation(summary = "구독 페이지 - 나를 구독한 블로그 정보 조회", description = "나를 구독한 블로그 정보를 조회합니다.")
-    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
-    @GetMapping("/followers")
-    public ApiResponse<BlogItemList> getFollows(HttpServletRequest request,
-        @RequestParam(defaultValue = "0") int page) {
+//    @Operation(summary = "구독 페이지 - 나를 구독한 블로그와 포스트 모두 정보 조회", description = "나를 구독한 블로그와 포스트 정보를 모두 조회합니다.")
+//    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
+//    @GetMapping("/subscribers")
+//    public ApiResponse<SubscriptionResponse.SubscriptionResult> getSubscriptionTo(
+//        HttpServletRequest request, @RequestParam(defaultValue = "0") int page) {
+//
+//        Long memberId = jwtProvider.getUserIdFromToken(request);
+//        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+//
+//        BlogItemList blogInfoList = blogQueryService.getSubscriberBlogList(blogId, page);
+//        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostTo(
+//            blogId, page);
+//
+//        return ApiResponse.onSuccess(
+//            SubscriptionResponse.toSubscriptionResult(blogInfoList, postItemList));
+//    }
+//
+//    @Operation(summary = "구독 페이지 - 나를 구독한 블로그 정보 조회", description = "나를 구독한 블로그 정보를 조회합니다.")
+//    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
+//    @GetMapping("/followers")
+//    public ApiResponse<BlogItemList> getFollowers(HttpServletRequest request,
+//        @RequestParam(defaultValue = "0") int page) {
+//
+//        Long memberId = jwtProvider.getUserIdFromToken(request);
+//        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+//
+//        return ApiResponse.onSuccess(blogQueryService.getSubscriberBlogList(blogId, page));
+//    }
+//
+//    @Operation(summary = "구독 페이지 - 나를 구독한 블로그의 포스트 정보 조회", description = "나를 구독한 블로그의 포스트 정보를 조회합니다.")
+//    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
+//    @GetMapping("/followers/posts")
+//    public ApiResponse<PostItemList> getFollowersPosts(HttpServletRequest request,
+//        @RequestParam(defaultValue = "0") int page) {
+//
+//        Long memberId = jwtProvider.getUserIdFromToken(request);
+//        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
+//
+//        return ApiResponse.onSuccess(subscriptionQueryService.getSubscriptionPostTo(
+//            blogId, page));
+//    }
 
-        Long memberId = jwtProvider.getUserIdFromToken(request);
-        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
-
-        return ApiResponse.onSuccess(blogQueryService.getSubscriberBlogList(blogId, page));
-    }
-
-    @Operation(summary = "구독 페이지 - 나를 구독한 블로그의 포스트 정보 조회", description = "나를 구독한 블로그의 포스트 정보를 조회합니다.")
-    @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", example = "0", in = ParameterIn.QUERY)
-    @GetMapping("/followers/posts")
-    public ApiResponse<PostItemList> getFollowsPosts(HttpServletRequest request,
-        @RequestParam(defaultValue = "0") int page) {
-
-        Long memberId = jwtProvider.getUserIdFromToken(request);
-        Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
-
-        return ApiResponse.onSuccess(subscriptionQueryService.getSubscriptionPostTo(
-            blogId, page));
+    @Operation(summary = "구독 페이지 - Open feign요청입니다.(로그인한 사용자가 구독한 블로그인지 확인)", description = "로그인한 사용자가 구독한 블로그인지 확인합니다.")
+    @PostMapping
+    public Boolean getLoginSubscribed(
+            @RequestBody SubscriptionRequest.LoginSubscription loginSubscription) {
+        return subscriptionQueryService.findLoginSubscribe(loginSubscription);
     }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionRequest.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionRequest.java
@@ -1,0 +1,19 @@
+package com.justdo.plug.blog.domain.subscription.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+public class SubscriptionRequest {
+
+    @Schema(description = "로그인한 사용자의 정보와 블로그의 정보 DTO")
+    @Getter
+    public static class LoginSubscription {
+
+        @Schema(description = "로그인한 사용자의 아이디")
+        private Long memberId;
+
+        @Schema(description = "포스트가 작성된 블로그의 아이디")
+        private Long blogId;
+    }
+
+}

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
@@ -1,12 +1,15 @@
 package com.justdo.plug.blog.domain.subscription.dto;
 
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItem;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
-import com.justdo.plug.blog.domain.post.PostResponse;
+import com.justdo.plug.blog.domain.post.PostResponse.PostItem;
 import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
 import com.justdo.plug.blog.domain.subscription.Subscription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,36 +34,94 @@ public class SubscriptionResponse {
     public static SubscriptionProc toSubscriptionProc(Subscription subscription) {
 
         return SubscriptionProc.builder()
-            .subscriptionId(subscription.getId())
-            .createdAt(LocalDateTime.now())
-            .build();
+                .subscriptionId(subscription.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 
     public static Subscription toEntity(Long memberId, Long blogId) {
 
         return Subscription.builder()
-            .fromMemberId(memberId)
-            .toBlogId(blogId)
-            .build();
+                .fromMemberId(memberId)
+                .toBlogId(blogId)
+                .build();
     }
 
-    @Schema(description = "내가 구독한 블로그의 정보 응답 DTO")
+    @Schema(description = "내가 구독한 블로그의 모든 정보 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class SubscriptionResult {
 
-        BlogResponse.BlogItemList blogItemList;
-        PostResponse.PostItemList postItemList;
+        private BlogResponse.BlogItemList blogItemList;
+        private BlogPostItem blogPostItem;
     }
 
     public static SubscriptionResult toSubscriptionResult(BlogItemList blogItemList,
-        PostItemList postItemList) {
+            BlogPostItem blogPostItem) {
 
         return SubscriptionResult.builder()
-            .blogItemList(blogItemList)
-            .postItemList(postItemList)
-            .build();
+                .blogItemList(blogItemList)
+                .blogPostItem(blogPostItem)
+                .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class SubscribedBlogPost {
+
+        private BlogItem blogItem;
+        private PostItem postItem;
+    }
+
+    public static SubscribedBlogPost toSubscribedBlogPost(PostItem postItem,
+            BlogItem blogItem) {
+
+        return SubscribedBlogPost.builder()
+                .blogItem(blogItem)
+                .postItem(postItem)
+                .build();
+    }
+
+    @Schema(description = "내가 구독한 블로그의 포스트 정보 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogPostItem {
+
+        @Schema(description = "구독한 블로그 정보와 포스트 정보가 담긴 DTO")
+        private List<SubscribedBlogPost> subscribedBlogPosts;
+
+        @Schema(description = "추가 목록이 있는 지의 여부")
+        private Boolean hasNext;
+
+        @Schema(description = "첫 페이지인지의 여부")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지인지의 여부")
+        private Boolean isLast;
+    }
+
+    public static BlogPostItem toBlogPostItem(PostItemList postItemList,
+            List<BlogItem> blogItemList) {
+
+        List<PostItem> postItems = postItemList.getPostItems();
+
+        List<SubscribedBlogPost> subscribedBlogPosts = IntStream.range(0,
+                        postItems.size())
+                .mapToObj(i -> toSubscribedBlogPost(postItems.get(i), blogItemList.get(i)))
+                .toList();
+
+        return BlogPostItem.builder()
+                .subscribedBlogPosts(subscribedBlogPosts)
+                .hasNext(postItemList.getHasNext())
+                .isFirst(postItemList.getIsFirst())
+                .isLast(postItemList.getIsLast())
+                .build();
     }
 }
+

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionCommandService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionCommandService.java
@@ -4,7 +4,6 @@ import com.justdo.plug.blog.domain.subscription.Subscription;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse.SubscriptionProc;
 import com.justdo.plug.blog.domain.subscription.repository.SubscriptionRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubscriptionCommandService {
 
     private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionQueryService subscriptionQueryService;
 
     public SubscriptionProc subscribe(Long memberId, Long blogId) {
-        return getSubscription(memberId, blogId)
-            .map(this::updateSubscription)
-            .orElseGet(() -> createSubscription(memberId, blogId)); // Create new
+        return subscriptionQueryService.getSubscription(memberId, blogId)
+                .map(this::updateSubscription)
+                .orElseGet(() -> createSubscription(memberId, blogId)); // Create new
     }
 
     private SubscriptionProc updateSubscription(Subscription existSub) {
@@ -37,7 +37,4 @@ public class SubscriptionCommandService {
         subscriptionRepository.save(subscription);
     }
 
-    public Optional<Subscription> getSubscription(Long memberId, Long blogId) {
-        return subscriptionRepository.findByFromMemberIdAndToBlogId(memberId, blogId);
-    }
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -1,10 +1,13 @@
 package com.justdo.plug.blog.domain.subscription.service;
 
 import com.justdo.plug.blog.domain.post.PostClient;
+import com.justdo.plug.blog.domain.post.PostResponse.PostItem;
 import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
 import com.justdo.plug.blog.domain.subscription.Subscription;
+import com.justdo.plug.blog.domain.subscription.dto.SubscriptionRequest.LoginSubscription;
 import com.justdo.plug.blog.domain.subscription.repository.SubscriptionRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -26,6 +29,12 @@ public class SubscriptionQueryService {
         return postClient.findSubscriptionFrom(blogIdList, page);
     }
 
+    public List<Long> getPostOfBlogIds(PostItemList postItemList) {
+        return postItemList.getPostItems().stream()
+                .map(PostItem::getBlogId)
+                .toList();
+    }
+
     // 나를 구독하는 블로그의 포스트 정보 조회
     public PostItemList getSubscriptionPostTo(Long blogId, int page) {
 
@@ -40,9 +49,9 @@ public class SubscriptionQueryService {
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
 
         return subscriptionRepository.findAllByFromMemberIdAndStateIsTrue(memberId, pageRequest)
-            .stream()
-            .map(Subscription::getToBlogId)
-            .toList();
+                .stream()
+                .map(Subscription::getToBlogId)
+                .toList();
     }
 
     // 나를 구독하는 블로그 사용자의 아이디 목록 조회
@@ -50,9 +59,19 @@ public class SubscriptionQueryService {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
         return subscriptionRepository.findAllByToBlogIdAndStateIsTrue(blogId, pageRequest)
-            .stream()
-            .map(Subscription::getFromMemberId)
-            .toList();
+                .stream()
+                .map(Subscription::getFromMemberId)
+                .toList();
 
+    }
+
+    public Optional<Subscription> getSubscription(Long memberId, Long blogId) {
+        return subscriptionRepository.findByFromMemberIdAndToBlogId(memberId, blogId);
+    }
+
+    public Boolean findLoginSubscribe(LoginSubscription loginSubscription) {
+
+        return getSubscription(loginSubscription.getMemberId(),
+                loginSubscription.getBlogId()).isPresent();
     }
 }


### PR DESCRIPTION
## 📌 요약

1. 내가 구독한 블로그의 포스트 조회 시 정보 추가 전달 
2. 로그인한 사용자 기준 블로그 구독 여부 API 구현

## 📝 상세 내용

2번 사항은 post-server와 통신하여 프론트에게 응답값을 반환합니다.

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
