### PR TITLE
Glue 331 Feat: 로그인한 사용자에 따른 유사 블로그 추천 API 구현

### DIFF
--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -4,16 +4,19 @@ import com.justdo.plug.blog.domain.blog.dto.BlogRequest;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogInfoList;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogPage;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogProc;
+import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogRecommend;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.CommentBlog;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.ImageResult;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.MyBlogResult;
 import com.justdo.plug.blog.domain.blog.service.BlogCommandService;
 import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
 import com.justdo.plug.blog.global.response.ApiResponse;
+import com.justdo.plug.blog.global.utils.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -36,6 +39,7 @@ public class BlogController {
 
     private final BlogCommandService blogCommandService;
     private final BlogQueryService blogQueryService;
+    private final JwtProvider jwtProvider;
 
     @Operation(summary = "회원 가입 - Open feign 요청 (회원 가입 시 자동으로 블로그 생성을 요청합니다.)", description = "사용자 회원가입 시 자동으로 하나의 블로그가 생성됩니다.")
     @PostMapping
@@ -89,6 +93,14 @@ public class BlogController {
     public List<CommentBlog> commentPost(@RequestBody List<Long> memberIdList) {
 
         return blogQueryService.getCommentsBlog(memberIdList);
+    }
+
+    @PostMapping("/recommendations")
+    public ApiResponse<List<BlogRecommend>> recommendBlogs(HttpServletRequest request) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+
+        return ApiResponse.onSuccess(blogQueryService.findRecommendBlog(memberId));
     }
 
 }

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -237,7 +237,7 @@ public class BlogResponse {
                 .build();
     }
 
-    @Schema(description = "댓글의 블로그 정보 Request DTO - Open Feign을 통해 Post-Server로 전달 ")
+    @Schema(description = "댓글의 블로그 정보 Request DTO - Open Feign을 통해 Post-Server로 전달")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
@@ -256,6 +256,28 @@ public class BlogResponse {
         return CommentBlog.builder()
                 .profile(blog.getProfile())
                 .title(blog.getTitle())
+                .build();
+    }
+
+    @Schema(description = "블로그 매칭 시 보여줄 블로그 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class BlogRecommend {
+
+        private String profile;
+        private String title;
+        private String description;
+
+    }
+
+    public static BlogRecommend toBlogRecommend(Blog blog) {
+
+        return BlogRecommend.builder()
+                .profile(blog.getProfile())
+                .title(blog.getTitle())
+                .description(blog.getDescription())
                 .build();
     }
 

--- a/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationClient.java
+++ b/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationClient.java
@@ -1,0 +1,16 @@
+package com.justdo.plug.blog.domain.recommendation;
+
+import com.justdo.plug.blog.domain.recommendation.RecommendationDTO.RecommendationRequest;
+import com.justdo.plug.blog.global.config.FeignConfig;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "recommend-service", url = "${application.config.recommends-url}", configuration = {
+        FeignConfig.class})
+public interface RecommendationClient {
+
+    @PostMapping
+    List<Long> getRecommendBlogs(@RequestBody RecommendationRequest request);
+}

--- a/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationDTO.java
+++ b/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationDTO.java
@@ -1,0 +1,24 @@
+package com.justdo.plug.blog.domain.recommendation;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RecommendationDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecommendationRequest {
+
+        private Long blogId;
+        private List<Long> followsId;
+    }
+
+    public static RecommendationRequest toRecommendationRequest(Long blogId, List<Long> followsId) {
+
+        return new RecommendationRequest(blogId, followsId);
+    }
+
+}

--- a/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationDTO.java
+++ b/src/main/java/com/justdo/plug/blog/domain/recommendation/RecommendationDTO.java
@@ -13,12 +13,12 @@ public class RecommendationDTO {
     public static class RecommendationRequest {
 
         private Long blogId;
-        private List<Long> followsId;
+        private List<Long> followIds;
     }
 
-    public static RecommendationRequest toRecommendationRequest(Long blogId, List<Long> followsId) {
+    public static RecommendationRequest toRecommendationRequest(Long blogId, List<Long> followIds) {
 
-        return new RecommendationRequest(blogId, followsId);
+        return new RecommendationRequest(blogId, followIds);
     }
 
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
@@ -13,4 +13,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     List<Subscription> findAllByFromMemberIdAndStateIsTrue(Long fromMemberId, PageRequest pageRequest);
 
     List<Subscription> findAllByToBlogIdAndStateIsTrue(Long toBlogId, PageRequest pageRequest);
+
+    List<Subscription> findFromAllByFromMemberIdAndStateIsTrue(Long fromMemberId);
+
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -74,4 +74,12 @@ public class SubscriptionQueryService {
         return getSubscription(loginSubscription.getMemberId(),
                 loginSubscription.getBlogId()).isPresent();
     }
+
+    public List<Long> getMySubscriptionBlogIdList(Long memberId) {
+
+        return subscriptionRepository.findFromAllByFromMemberIdAndStateIsTrue(memberId)
+                .stream()
+                .map(Subscription::getToBlogId)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 📌 요약

- 로그인한 사용자에 따른 유사 블로그 추천 API 구현
- 프론트엔드에서 "/blogs/recommendations"로 POST 요청을 보내면 팔로우 하지 않은 블로그의 정보를 4개 전달합니다.
  - Blog-Server에서는 구독한 blogId 리스트를 Recommend-Server에 전달하여, 이를 제외하여 유사한 블로그의 blogId를 전달받습니다.
- 유사 블로그 추천은 최대 4개를 전달합니다.
## 📝 상세 내용

<img width="945" alt="image" src="https://github.com/DoTheZ-Team/blog-service/assets/103489352/ccb0ba68-8d46-4491-861d-38342d5b2390">


## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
