### PR TITLE
hotfix: 구독페이지 API에서 페이징 오류 해결

### DIFF
--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -3,6 +3,7 @@ package com.justdo.plug.blog.domain.blog.dto;
 import com.justdo.plug.blog.domain.blog.Blog;
 import com.justdo.plug.blog.domain.member.MemberDTO;
 import com.justdo.plug.blog.domain.post.PostResponse.BlogPostItem;
+import com.justdo.plug.blog.domain.subscription.Subscription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -193,18 +194,19 @@ public class BlogResponse {
         private Boolean isLast;
     }
 
-    public static BlogItemList toBlogItemList(List<String> nicknames, Slice<Blog> blogs) {
+    public static BlogItemList toBlogItemList(List<String> nicknames, List<Blog> blogs,
+            Slice<Subscription> subscriptionSlice) {
 
         List<BlogItem> blogItems = IntStream.range(0,
-                        Math.min(nicknames.size(), blogs.getContent().size()))
-                .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.getContent().get(i)))
+                        Math.min(nicknames.size(), blogs.size()))
+                .mapToObj(i -> toBlogItem(nicknames.get(i), blogs.get(i)))
                 .collect(Collectors.toList());
 
         return BlogItemList.builder()
                 .blogItems(blogItems)
-                .hasNext(blogs.hasNext())
-                .isFirst(blogs.isFirst())
-                .isLast(blogs.isLast())
+                .hasNext(subscriptionSlice.hasNext())
+                .isFirst(subscriptionSlice.isFirst())
+                .isLast(subscriptionSlice.isLast())
                 .build();
     }
 

--- a/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/repository/BlogRepository.java
@@ -4,17 +4,16 @@ import com.justdo.plug.blog.domain.blog.Blog;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface BlogRepository extends JpaRepository<Blog, Long> {
 
     @Query("SELECT b FROM Blog b WHERE b.id in :blogIdList")
-    Slice<Blog> findBlogIdList(List<Long> blogIdList, PageRequest pageRequest);
+    List<Blog> findBlogIdList(List<Long> blogIdList);
 
     @Query("SELECT b FROM Blog b WHERE b.memberId in :memberIdList")
-    Slice<Blog> findSubscriberIdList(List<Long> memberIdList, PageRequest pageRequest);
+    List<Blog> findSubscriberIdList(List<Long> memberIdList);
 
     Blog findByMemberId(Long memberId);
 

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/controller/SubscriptionController.java
@@ -4,6 +4,7 @@ import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItem;
 import com.justdo.plug.blog.domain.blog.dto.BlogResponse.BlogItemList;
 import com.justdo.plug.blog.domain.blog.service.BlogQueryService;
 import com.justdo.plug.blog.domain.post.PostResponse.PostItemList;
+import com.justdo.plug.blog.domain.subscription.Subscription;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionRequest;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse;
 import com.justdo.plug.blog.domain.subscription.dto.SubscriptionResponse.BlogPostItem;
@@ -61,10 +62,13 @@ public class SubscriptionController {
         BlogItemList blogItemList = blogQueryService.getBlogInfoList(memberId, page);
 
         /** 오른쪽 구독한 블로그의 포스트 정보**/
-        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostFrom(
-                memberId, page);
-        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<Subscription> subscriptions = subscriptionQueryService.getMySubscriptions(memberId);
+        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostItems(
+                subscriptions, page);
+        List<Long> postOfBlogIds = subscriptionQueryService.getBlogIdsFromPostItemList(
+                postItemList);
         List<BlogItem> blogItems = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
+
         BlogPostItem blogPostItem = SubscriptionResponse.toBlogPostItem(postItemList,
                 blogItems);
 
@@ -89,9 +93,11 @@ public class SubscriptionController {
             @RequestParam(defaultValue = "0") int page) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostFrom(
-                memberId, page);
-        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<Subscription> subscriptions = subscriptionQueryService.getMySubscriptions(memberId);
+        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostItems(
+                subscriptions, page);
+        List<Long> postOfBlogIds = subscriptionQueryService.getBlogIdsFromPostItemList(
+                postItemList);
         List<BlogItem> blogItemList = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
 
         return ApiResponse.onSuccess(
@@ -108,10 +114,14 @@ public class SubscriptionController {
         Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
 
         BlogItemList blogItemList = blogQueryService.getSubscriberBlogList(blogId, page);
-        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostTo(
-                blogId, page);
 
-        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<Subscription> subscriptions = subscriptionQueryService.getMySubscribers(
+                blogId);
+        PostItemList postItemList = subscriptionQueryService.getSubscriberPostItems(
+                subscriptions, page);
+
+        List<Long> postOfBlogIds = subscriptionQueryService.getBlogIdsFromPostItemList(
+                postItemList);
         List<BlogItem> blogItems = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
         BlogPostItem blogPostItem = SubscriptionResponse.toBlogPostItem(postItemList,
                 blogItems);
@@ -141,10 +151,12 @@ public class SubscriptionController {
         Long memberId = jwtProvider.getUserIdFromToken(request);
         Long blogId = blogQueryService.findBlogIdByMemberId(memberId);
 
-        PostItemList postItemList = subscriptionQueryService.getSubscriptionPostTo(blogId,
-                page);
+        List<Subscription> subscriptions = subscriptionQueryService.getMySubscribers(blogId);
+        PostItemList postItemList = subscriptionQueryService.getSubscriberPostItems(
+                subscriptions, page);
 
-        List<Long> postOfBlogIds = subscriptionQueryService.getPostOfBlogIds(postItemList);
+        List<Long> postOfBlogIds = subscriptionQueryService.getBlogIdsFromPostItemList(
+                postItemList);
         List<BlogItem> blogItemList = blogQueryService.getPostOfBlogInfoList(postOfBlogIds);
 
         return ApiResponse.onSuccess(

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/dto/SubscriptionResponse.java
@@ -9,7 +9,9 @@ import com.justdo.plug.blog.domain.subscription.Subscription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -77,8 +79,7 @@ public class SubscriptionResponse {
         private PostItem postItem;
     }
 
-    public static BlogPostPreview toBlogPostPreview(PostItem postItem,
-            BlogItem blogItem) {
+    public static BlogPostPreview toBlogPostPreview(BlogItem blogItem, PostItem postItem) {
 
         return BlogPostPreview.builder()
                 .blogItem(blogItem)
@@ -109,12 +110,8 @@ public class SubscriptionResponse {
     public static BlogPostItem toBlogPostItem(PostItemList postItemList,
             List<BlogItem> blogItemList) {
 
-        List<PostItem> postItems = postItemList.getPostItems();
-
-        List<BlogPostPreview> blogPostPreviews = IntStream.range(0,
-                        postItems.size())
-                .mapToObj(i -> toBlogPostPreview(postItems.get(i), blogItemList.get(i)))
-                .toList();
+        List<BlogPostPreview> blogPostPreviews = getBlogPostPreviews(postItemList.getPostItems(),
+                blogItemList);
 
         return BlogPostItem.builder()
                 .blogPostPreviews(blogPostPreviews)
@@ -122,6 +119,20 @@ public class SubscriptionResponse {
                 .isFirst(postItemList.getIsFirst())
                 .isLast(postItemList.getIsLast())
                 .build();
+    }
+
+    private static List<BlogPostPreview> getBlogPostPreviews(List<PostItem> postItemList,
+            List<BlogItem> blogItemList) {
+
+        Map<Long, BlogItem> blogItemMap = blogItemList.stream()
+                .collect(Collectors.toMap(BlogItem::getBlogId, Function.identity()));
+
+        return postItemList.stream()
+                .map(postItem -> {
+                    BlogItem blogItem = blogItemMap.get(postItem.getBlogId());
+                    return toBlogPostPreview(blogItem, postItem);
+                })
+                .collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/repository/SubscriptionRepository.java
@@ -4,16 +4,21 @@ import com.justdo.plug.blog.domain.subscription.Subscription;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     Optional<Subscription> findByFromMemberIdAndToBlogId(Long fromMemberId, Long toBlogId);
 
-    List<Subscription> findAllByFromMemberIdAndStateIsTrue(Long fromMemberId, PageRequest pageRequest);
+    List<Subscription> findAllByFromMemberIdAndStateIsTrue(Long fromMemberId);
 
-    List<Subscription> findAllByToBlogIdAndStateIsTrue(Long toBlogId, PageRequest pageRequest);
+    Slice<Subscription> findSliceAllByFromMemberIdAndStateIsTrue(Long fromMemberId,
+            PageRequest pageRequest);
 
-    List<Subscription> findFromAllByFromMemberIdAndStateIsTrue(Long fromMemberId);
+    List<Subscription> findAllByToBlogIdAndStateIsTrue(Long toBlogId);
+
+    Slice<Subscription> findSliceAllByToBlogIdAndStateIsTrue(Long toBlogId,
+            PageRequest pageRequest);
 
 }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,47 +23,59 @@ public class SubscriptionQueryService {
     private final PostClient postClient;
     private final SubscriptionRepository subscriptionRepository;
 
-    public PostItemList getSubscriptionPostFrom(Long memberId, int page) {
+    // 나의 구독 목록 조회
+    public List<Subscription> getMySubscriptions(Long memberId) {
 
-        List<Long> blogIdList = getSubscriptionBlogIdList(memberId, page);
+        return subscriptionRepository.findAllByFromMemberIdAndStateIsTrue(memberId);
+
+    }
+
+    public Slice<Subscription> getMySubscriptionsSlice(Long memberId, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+
+        return subscriptionRepository.findSliceAllByFromMemberIdAndStateIsTrue(memberId,
+                pageRequest);
+
+    }
+
+    // 구독한 블로그의 포스트 정보 가져오기
+    public PostItemList getSubscriptionPostItems(List<Subscription> subscriptions, int page) {
+
+        List<Long> blogIdList = subscriptions.stream()
+                .map(Subscription::getToBlogId)
+                .toList();
 
         return postClient.findSubscriptionFrom(blogIdList, page);
     }
 
-    public List<Long> getPostOfBlogIds(PostItemList postItemList) {
+    public List<Long> getBlogIdsFromPostItemList(PostItemList postItemList) {
         return postItemList.getPostItems().stream()
                 .map(PostItem::getBlogId)
                 .toList();
     }
 
+    // 나의 구독자 목록 조회
+    public List<Subscription> getMySubscribers(Long blogId) {
+
+        return subscriptionRepository.findAllByToBlogIdAndStateIsTrue(blogId);
+    }
+
+    public Slice<Subscription> getMySubscribersSlice(Long blogId, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
+
+        return subscriptionRepository.findSliceAllByToBlogIdAndStateIsTrue(blogId, pageRequest);
+    }
+
     // 나를 구독하는 블로그의 포스트 정보 조회
-    public PostItemList getSubscriptionPostTo(Long blogId, int page) {
+    public PostItemList getSubscriberPostItems(List<Subscription> subscriptions, int page) {
 
-        List<Long> subscriberIdList = getSubscriberBlogIdList(blogId, page);
-
-        return postClient.findSubscriptionTo(subscriberIdList, page);
-    }
-
-    // 내가 구독하는 블로그 사용자의 아이디 목록 조회
-    public List<Long> getSubscriptionBlogIdList(Long memberId, int page) {
-
-        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
-
-        return subscriptionRepository.findAllByFromMemberIdAndStateIsTrue(memberId, pageRequest)
-                .stream()
-                .map(Subscription::getToBlogId)
-                .toList();
-    }
-
-    // 나를 구독하는 블로그 사용자의 아이디 목록 조회
-    public List<Long> getSubscriberBlogIdList(Long blogId, int page) {
-
-        PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("createdAt"));
-        return subscriptionRepository.findAllByToBlogIdAndStateIsTrue(blogId, pageRequest)
-                .stream()
+        List<Long> subscriberIdList = subscriptions.stream()
                 .map(Subscription::getFromMemberId)
                 .toList();
 
+        return postClient.findSubscriptionTo(subscriberIdList, page);
     }
 
     public Optional<Subscription> getSubscription(Long memberId, Long blogId) {
@@ -77,7 +90,7 @@ public class SubscriptionQueryService {
 
     public List<Long> getMySubscriptionBlogIdList(Long memberId) {
 
-        return subscriptionRepository.findFromAllByFromMemberIdAndStateIsTrue(memberId)
+        return subscriptionRepository.findAllByFromMemberIdAndStateIsTrue(memberId)
                 .stream()
                 .map(Subscription::getToBlogId)
                 .toList();


### PR DESCRIPTION
## 📌 요약

- 구독페이지 API에서 페이징 오류 해결
- blog-server와 post-server와 통신하여 얻은 값을 페이징해서 반환하는데, 페이징이 잘못 적용 되어, 2번째 페이지가 조회되지 않는 오류를 해결하였습니다. 

## 📝 상세 내용

<img width="660" alt="image" src="https://github.com/DoTheZ-Team/blog-service/assets/103489352/0bb3a8e8-3c2f-4ea7-a82e-64ea8b19e1f6">

<img width="660" alt="image" src="https://github.com/DoTheZ-Team/blog-service/assets/103489352/57ad56dc-e82c-47a6-a959-44c7e721ffa9">


## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
