### PR TITLE
Fix : 비로그인 사용자의 블로그 페이지 조회가 가능하도록 로직 수정

### DIFF
--- a/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/controller/BlogController.java
@@ -55,8 +55,8 @@ public class BlogController {
     public ApiResponse<BlogPage> getBlogPage(HttpServletRequest request,
             @PathVariable Long blogId) {
 
-        Long loginMemberId = jwtProvider.getUserIdFromToken(request);
-        Long loginBlogId = jwtProvider.getBlogIdFromToken(request);
+        Long loginMemberId = jwtProvider.getUserIdFromTokenNullCheck(request);
+        Long loginBlogId = jwtProvider.getBlogIdFromTokenNullCheck(request);
 
         return ApiResponse.onSuccess(
                 blogQueryService.findBlogPage(blogId, loginMemberId, loginBlogId));

--- a/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/dto/BlogResponse.java
@@ -271,10 +271,10 @@ public class BlogResponse {
         @Schema(description = "로그인 한 사용자의 블로그 아이디", example = "1")
         private Long loginBlogId;
 
-        @Schema(description = "로그인 한 사용자의 이름", example = "예영2")
+        @Schema(description = "블로그 주인의 사용자 이름", example = "예영2")
         private String memberName;
 
-        @Schema(description = "로그인 한 사용자의 블로그 구독 여부")
+        @Schema(description = "로그인 한 사용자의 해당 블로그 구독 여부")
         private Boolean isSubscribe;
 
         private BlogInfo blogInfo;

--- a/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/blog/service/BlogQueryService.java
@@ -29,6 +29,7 @@ import com.justdo.plug.blog.global.response.code.status.ErrorStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -157,13 +158,13 @@ public class BlogQueryService {
     public BlogPage findBlogPage(Long blogId, Long loginMemberId, Long loginBlogId) {
 
         Blog blog = findById(blogId);
-
         BlogInfo blogInfo = toBlogInfo(blog);
         BlogPostItem blogPostItem = postClient.findBlogPostItem(blogId);
         String memberName = memberClient.findMemberName(blog.getMemberId());
 
-        boolean isSubscribe = subscriptionQueryService.getSubscription(loginMemberId, blogId)
-                .isPresent();
+        boolean isSubscribe = Optional.ofNullable(loginMemberId)
+                .map(mid -> subscriptionQueryService.getSubscription(mid, blogId).isPresent())
+                .orElse(false);
 
         return toBlogpage(loginBlogId, memberName, isSubscribe, blogInfo, blogPostItem);
     }

--- a/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
+++ b/src/main/java/com/justdo/plug/blog/domain/subscription/service/SubscriptionQueryService.java
@@ -79,7 +79,9 @@ public class SubscriptionQueryService {
     }
 
     public Optional<Subscription> getSubscription(Long memberId, Long blogId) {
-        return subscriptionRepository.findByFromMemberIdAndToBlogId(memberId, blogId);
+
+        return Optional.ofNullable(memberId)
+                .flatMap(mid -> subscriptionRepository.findByFromMemberIdAndToBlogId(mid, blogId));
     }
 
     public Boolean findLoginSubscribe(LoginSubscription loginSubscription) {

--- a/src/main/java/com/justdo/plug/blog/global/utils/JwtProvider.java
+++ b/src/main/java/com/justdo/plug/blog/global/utils/JwtProvider.java
@@ -37,11 +37,26 @@ public class JwtProvider {
         return validateToken(accessToken);
     }
 
-    public Long getBlogIdFromToken(HttpServletRequest request) {
+    public Long getUserIdFromTokenNullCheck(HttpServletRequest request) {
 
-        String accessToken = parseToken(request);
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
 
-        return validateTokenWithBlogId(accessToken);
+        if (bearerToken == null || bearerToken.isEmpty()) {
+            return null;
+        } else {
+            return validateToken(bearerToken.substring(TOKEN_SPLIT));
+        }
+    }
+
+    public Long getBlogIdFromTokenNullCheck(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+
+        if (bearerToken == null || bearerToken.isEmpty()) {
+            return null;
+        } else {
+            return validateTokenWithBlogId(bearerToken.substring(TOKEN_SPLIT));
+        }
     }
 
     private String parseToken(HttpServletRequest request) {


### PR DESCRIPTION
## 📌 요약

- 비로그인 사용자의 블로그 페이지 조회가 가능하도록 로직 수정
- JwtProvider.class JWT 파싱 함수 추가
> 기존에는 jwt null이면 에러 발생하였음 -> 특정 API의 경우 추가한 getUserIdFromTokenNullCheck 메서드로 처리
- loginMeberId의 null 여부에 따른 구독 여부 처리

## 📝 상세 내용

-

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
